### PR TITLE
Add support for domain-insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ unbound_optimizations:
 
 # Default is to use syslog, which will log to /var/log/messages.
 unbound_use_syslog: true
+
+# Configures zones to disable DNSSEC for (useful for local unsigned DNS zones)
+unbound_insecure_domains: []
+# - insecure.local
 ```
 
 ## Dependencies

--- a/templates/etc/unbound/unbound.conf.d/local.conf.j2
+++ b/templates/etc/unbound/unbound.conf.d/local.conf.j2
@@ -62,6 +62,11 @@ server:
 {%     endif %}
 {%   endfor %}
 {% endif %}
+{% if unbound_insecure_domains is defined %}
+{%   for item in unbound_insecure_domains %}
+  domain-insecure: "{{ item }}"
+{%   endfor %}
+{% endif %}
 {% if unbound_forward_zones is defined %}
 {%   for item in unbound_forward_zones %}
   forward-zone:


### PR DESCRIPTION
This adds support for writing domain-insecure to the config file. This is useful because the default install on Debian enables DNSSEC, and it's useful to be able to disable it for internal domains.